### PR TITLE
Raspberry pi unicode

### DIFF
--- a/bot/build.gradle.kts
+++ b/bot/build.gradle.kts
@@ -36,6 +36,7 @@ tasks.withType<KotlinCompile> {
 
 val fatJar = task("fatJar", type = Jar::class) {
     archiveBaseName.set("${project.name}-fat")
+    archiveVersion.set("")
     manifest {
         attributes["Implementation-Title"] = "Discord Bot Jar"
         attributes["Implementation-Version"] = bot.Versions.botVersion

--- a/bot/build.gradle.kts
+++ b/bot/build.gradle.kts
@@ -35,16 +35,19 @@ tasks.withType<KotlinCompile> {
 }
 
 val fatJar = task("fatJar", type = Jar::class) {
-    archiveBaseName.set("${project.name}-fat")
+    archiveBaseName.set("${project.name}-release")
     archiveVersion.set("")
+    exclude("META-INF/*.RSA", "META-INF/*.SF", "META-INF/*.DSA")
+    from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) })
+    with(tasks.jar.get() as CopySpec)
+}
+
+tasks.withType<Jar> {
     manifest {
         attributes["Implementation-Title"] = "Discord Bot Jar"
         attributes["Implementation-Version"] = bot.Versions.botVersion
         attributes["Main-Class"] = "ca.allanwang.discord.bot.Bot"
     }
-    exclude("META-INF/*.RSA", "META-INF/*.SF", "META-INF/*.DSA")
-    from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) })
-    with(tasks.jar.get() as CopySpec)
 }
 
 tasks {

--- a/firebase/src/main/kotlin/ca/allanwang/discord/bot/firebase/FirebaseModule.kt
+++ b/firebase/src/main/kotlin/ca/allanwang/discord/bot/firebase/FirebaseModule.kt
@@ -54,7 +54,7 @@ object FirebaseModule {
     @Provides
     @JvmStatic
     @Singleton
-    fun firebaseDatabase(firebaseApp: FirebaseApp) = FirebaseDatabase.getInstance(firebaseApp)
+    fun firebaseDatabase(firebaseApp: FirebaseApp): FirebaseDatabase = FirebaseDatabase.getInstance(firebaseApp)
 
     @Provides
     @FirebaseRootRef

--- a/time/src/main/kotlin/ca/allanwang/discord/bot/time/TimeBot.kt
+++ b/time/src/main/kotlin/ca/allanwang/discord/bot/time/TimeBot.kt
@@ -163,8 +163,12 @@ class TimeBot @Inject constructor(
     }
 
     private suspend fun ReactionAddEvent.handleEvent() {
+        logger.atInfo().log("Receive event")
         if (!pendingReactionCache.containsKey(message.id)) return
+        logger.atInfo().log("Receive event in key")
+        logger.atInfo().log("Receive event emojis %s, %s", emoji.name, timeApi.reactionEmoji.name)
         if (emoji.name != timeApi.reactionEmoji.name) return
+        logger.atInfo().log("Receive event matches emoji")
         if (getUserOrNull()?.isBot == true) return
         logger.atInfo().log("Received reaction response")
         val message = getMessage()

--- a/time/src/main/kotlin/ca/allanwang/discord/bot/time/TimeBot.kt
+++ b/time/src/main/kotlin/ca/allanwang/discord/bot/time/TimeBot.kt
@@ -163,12 +163,9 @@ class TimeBot @Inject constructor(
     }
 
     private suspend fun ReactionAddEvent.handleEvent() {
-        logger.atInfo().log("Receive event")
         if (!pendingReactionCache.containsKey(message.id)) return
-        logger.atInfo().log("Receive event in key")
-        logger.atInfo().log("Receive event emojis %s, %s", emoji.name, timeApi.reactionEmoji.name)
+        logger.atInfo().log("Receive pending event with emoji %s", emoji.name)
         if (emoji.name != timeApi.reactionEmoji.name) return
-        logger.atInfo().log("Receive event matches emoji")
         if (getUserOrNull()?.isBot == true) return
         logger.atInfo().log("Received reaction response")
         val message = getMessage()


### PR DESCRIPTION
Previously, emoji comparisons weren't working on the raspberry pi because the unicode was outputting in the wrong format.

The fix was to update the locale to `en_US.UTF-8`

However, a separate thing blocking this was the lack of `LC_ALL`. Updating this key too made it work

https://raspberrypi.stackexchange.com/questions/43550/unable-to-reconfigure-locale-in-raspberry-pi