### PR TITLE
Fix duplicate time info

### DIFF
--- a/time/src/main/kotlin/ca/allanwang/discord/bot/time/TimeApi.kt
+++ b/time/src/main/kotlin/ca/allanwang/discord/bot/time/TimeApi.kt
@@ -44,9 +44,12 @@ class TimeApi @Inject constructor(
     suspend fun groupTimes(group: Snowflake): List<TimeZone> {
         return ref.child(group)
             .singleSnapshot().children
+            .asSequence()
             .mapNotNull { it.getValueOrNull<String>() }
-            .toSet()
+            .distinct()
             .mapNotNull { TimeZone.getTimeZone(it) }
+            .distinctBy { it.rawOffset }
             .sortedBy { it.rawOffset }
+            .toList()
     }
 }


### PR DESCRIPTION
TimeZones can have different ids and the same rawOffset. Remove those with duplicate offsets prior to display