### PR TITLE
Prefix handler

### DIFF
--- a/base/src/main/kotlin/ca/allanwang/discord/bot/base/CommandBuilder.kt
+++ b/base/src/main/kotlin/ca/allanwang/discord/bot/base/CommandBuilder.kt
@@ -5,11 +5,12 @@ import com.gitlab.kordlib.rest.builder.message.EmbedBuilder
 
 typealias CommandHandlerAction = suspend CommandHandlerEvent.() -> Unit
 
-class CommandHandlerEvent(
+data class CommandHandlerEvent(
     val event: MessageCreateEvent,
     val prefix: String,
     val command: String,
-    val message: String
+    val message: String,
+    val origMessage: String
 ) {
     val channel get() = event.message.channel
     val authorId get() = event.message.author?.id
@@ -29,7 +30,7 @@ interface CommandHandler {
 
     val keys: Set<String>
 
-    suspend fun handle(event: MessageCreateEvent, message: String)
+    suspend fun handle(event: CommandHandlerEvent)
 
     enum class Type {
         Prefix, Mention


### PR DESCRIPTION
While working on #16, I noticed that there was no way for commands to get the original prefix. I've decided to propagate that into the event, as well as the original event message. Handers now take in the single command handler event, and events are copied over with updates for each action