### PR TITLE
Create paginated message

### DIFF
--- a/base/src/main/kotlin/ca/allanwang/discord/bot/base/BaseExt.kt
+++ b/base/src/main/kotlin/ca/allanwang/discord/bot/base/BaseExt.kt
@@ -18,3 +18,22 @@ fun Kord.onMessage(consumer: suspend MessageCreateEvent.() -> Unit) = on<Message
     if (message.author?.isBot == true) return@on
     consumer()
 }
+
+fun List<String>.chunkedByLength(length: Int = 2048): List<String> {
+    val stringBuilder = StringBuilder()
+    val list = mutableListOf<String>()
+    forEach {
+        if (stringBuilder.length + it.length <= length) {
+            if (stringBuilder.isNotEmpty())
+                stringBuilder.appendLine()
+        } else {
+            list.add(stringBuilder.toString())
+            stringBuilder.clear()
+        }
+        stringBuilder.append(it)
+    }
+    if (stringBuilder.isNotEmpty()) {
+        list.add(stringBuilder.toString())
+    }
+    return list
+}

--- a/base/src/main/kotlin/ca/allanwang/discord/bot/base/BaseExt.kt
+++ b/base/src/main/kotlin/ca/allanwang/discord/bot/base/BaseExt.kt
@@ -19,7 +19,10 @@ fun Kord.onMessage(consumer: suspend MessageCreateEvent.() -> Unit) = on<Message
     consumer()
 }
 
-fun List<String>.chunkedByLength(length: Int = 2048): List<String> {
+fun List<String>.chunkedByLength(length: Int = 2048, emptyText: String? = null): List<String> {
+    if (isEmpty()) {
+        return if (emptyText != null) listOf(emptyText) else emptyList()
+    }
     val stringBuilder = StringBuilder()
     val list = mutableListOf<String>()
     forEach {

--- a/base/src/main/kotlin/ca/allanwang/discord/bot/base/MessageReactions.kt
+++ b/base/src/main/kotlin/ca/allanwang/discord/bot/base/MessageReactions.kt
@@ -18,6 +18,7 @@ suspend fun Message.confirmationReaction(user: Snowflake? = null): Boolean {
     addReaction(positive)
     addReaction(negative)
     return kord.events.filterIsInstance<ReactionAddEvent>()
+        .filter { it.userId != kord.selfId }
         .run { if (user == null) this else filter { it.userId == user } }
         .mapNotNull {
             when (it.emoji) {
@@ -48,7 +49,7 @@ suspend fun MessageChannelBehavior.paginatedMessage(
     fun EmbedBuilder.pageEmbed(index: Int) {
         description = descriptions[index]
         footer {
-            text = "$index/${descriptions.size}"
+            text = "${index + 1}/${descriptions.size}"
         }
     }
 
@@ -56,7 +57,11 @@ suspend fun MessageChannelBehavior.paginatedMessage(
         pageEmbed(currentIndex)
     }
 
+    message.addReaction(left)
+    message.addReaction(right)
+
     kord.events.filterIsInstance<ReactionAddEvent>()
+        .filter { it.userId != kord.selfId }
         .filter { it.emoji == left || it.emoji == right }
         .withTimeout(TimeUnit.MINUTES.toMillis(1))
         .collect {

--- a/base/src/test/kotlin/ca/allanwang/discord/bot/base/BaseExtTest.kt
+++ b/base/src/test/kotlin/ca/allanwang/discord/bot/base/BaseExtTest.kt
@@ -1,0 +1,16 @@
+package ca.allanwang.discord.bot.base
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+class BaseExtTest {
+
+    @Test
+    fun chunkBySize() {
+        val chunk = "abcde"
+        val source = MutableList(5) { chunk }
+
+        assertThat(source.chunkedByLength(12), equalTo(listOf("$chunk\n$chunk", "$chunk\n$chunk", chunk)))
+    }
+}

--- a/base/src/test/kotlin/ca/allanwang/discord/bot/base/BaseExtTest.kt
+++ b/base/src/test/kotlin/ca/allanwang/discord/bot/base/BaseExtTest.kt
@@ -13,4 +13,9 @@ class BaseExtTest {
 
         assertThat(source.chunkedByLength(12), equalTo(listOf("$chunk\n$chunk", "$chunk\n$chunk", chunk)))
     }
+
+    @Test
+    fun chunkBySizeEmpty() {
+        assertThat(emptyList<String>().chunkedByLength(emptyText = "Empty Text"), equalTo(listOf("Empty Text")))
+    }
 }

--- a/qotd/src/main/kotlin/ca/allanwang/discord/bot/qotd/QotdBot.kt
+++ b/qotd/src/main/kotlin/ca/allanwang/discord/bot/qotd/QotdBot.kt
@@ -415,12 +415,6 @@ class QotdBot @Inject constructor(
     private suspend fun CommandHandlerEvent.questions(showKey: Boolean = false) {
         val guildId = statusGuildId() ?: return
         val questions = api.questions(guildId)
-        if (questions.isEmpty()) {
-            channel.createQotd {
-                description = "No questions found"
-            }
-            return
-        }
         val questionText = questions.entries.mapIndexed { index, (key, q) ->
             buildString {
                 appendBold {
@@ -436,7 +430,7 @@ class QotdBot @Inject constructor(
                 append(q)
             }
         }
-        val questionPages = questionText.chunkedByLength()
+        val questionPages = questionText.chunkedByLength(emptyText = "No questions found")
 
         channel.paginatedMessage(questionPages) {
             createQotd(it)


### PR DESCRIPTION
qotd questions can be too long. Discord descriptions have a text limit of 2048. This should be applied to all messages, but as they should be split at different positions, the function will need to be added on an as is basis